### PR TITLE
Fix Flask server port and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Simulador sencillo de una empresa militar privada. Puedes abrir `templates/index.html` directamente o ejecutar `app.py` para lanzar la versión web con Flask.
 
+## Uso rápido
+
+1. Instala las dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Inicia el servidor Flask:
+
+```bash
+python app.py
+```
+
+El servidor quedará accesible en `http://localhost:5000` (o el puerto definido en la variable `PORT`).
+
 La interfaz fue modernizada con un archivo de estilos separado y animaciones suaves. Ahora cada soldado tiene atributos de lealtad, moral y especialización y puede ascender de rango.
 
 Esta carpeta incluye ahora un servidor Flask sencillo junto con la versión por consola del juego y módulos separados que gestionan el motor principal, personal y misiones.

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, render_template, request, jsonify
 from flask_sqlalchemy import SQLAlchemy
 
@@ -38,4 +39,5 @@ def api_accept_mission():
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()
-    app.run(debug=True)
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+flask-sqlalchemy
+psycopg2-binary


### PR DESCRIPTION
## Summary
- bind Flask to 0.0.0.0 and use env PORT
- document how to start the web server
- add requirements.txt for easy install

## Testing
- `python -m py_compile app.py game_engine.py economy.py missions.py models.py personnel.py reputation.py save_system.py utils.py main.py`
- `pip install -r requirements.txt`
- `python app.py` (checked server output)

------
https://chatgpt.com/codex/tasks/task_e_687f175ab1288333bb4060e879766602